### PR TITLE
Cron job

### DIFF
--- a/common/backup-scripts/db_backup.sh
+++ b/common/backup-scripts/db_backup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -ex
+
+BACKUP_DATE=$(date +"%Y%m%d_%H%M")
+BACKUP_DIR="/db_backups"
+
+# MySQL bağlantı bilgileri: backup_user + backup_pass
+HOST="${MYSQL_HOST:-proxysql}"
+PORT="${MYSQL_PORT:-6033}"
+USER="${MYSQL_USER:-backup_user}"
+PASS="${MYSQL_PASSWORD:-backup_pass}"
+DB="${MYSQL_DATABASE:-redmine}"
+
+# Yedek alma
+mysqldump -h "$HOST" -P "$PORT" -u"$USER" -p"$PASS" "$DB" \
+> "${BACKUP_DIR}/redmine_${BACKUP_DATE}.sql"
+
+# Sıkıştır
+gzip "${BACKUP_DIR}/redmine_${BACKUP_DATE}.sql"
+
+echo "[`date '+%Y-%m-%d %H:%M:%S'`] Backup complete: redmine_${BACKUP_DATE}.sql.gz"

--- a/common/backup-scripts/entrypoint.sh
+++ b/common/backup-scripts/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -ex
+
+# Cron için gerekli dosyayı doğru yere kopyala
+cp /scripts/root-cron /etc/crontabs/root
+
+# Foreground (-f) modda cron başlat; -l 2 ile log detay seviyesi
+crond -f -l 2

--- a/common/backup-scripts/root-cron
+++ b/common/backup-scripts/root-cron
@@ -1,0 +1,3 @@
+# Her gece 03:00'da db_backup.sh çalışsın
+# 0 3 * * * /scripts/db_backup.sh >> /db_backups/db_backup.log 2>&1
+*/3 * * * * /scripts/db_backup.sh >> /db_backups/db_backup.log 2>&1

--- a/common/config/proxysql.cnf
+++ b/common/config/proxysql.cnf
@@ -97,6 +97,13 @@ mysql_users =
         max_connections=1000
         active = 1
         transaction_persistent=1
+    },
+    {
+        username = "backup_user"
+        password = "backup_pass"
+        default_hostgroup = 10
+        active = 1
+        transaction_persistent=1
     }
 )
 

--- a/with-db/docker-compose.yml
+++ b/with-db/docker-compose.yml
@@ -444,8 +444,8 @@ services:
       - proxysql       # yedeği proxysql üzerinden alıyoruz
     command: /bin/sh -c "apk update && apk add --no-cache mariadb-client && /scripts/entrypoint.sh"
     environment:
-      - MYSQL_HOST=proxysql
-      - MYSQL_PORT=6033
+      - MYSQL_HOST=slave3
+      - MYSQL_PORT=3306 
       - MYSQL_USER=backup_user
       - MYSQL_PASSWORD=backup_pass
       - MYSQL_DATABASE=redmine

--- a/with-db/docker-compose.yml
+++ b/with-db/docker-compose.yml
@@ -201,7 +201,7 @@ services:
       DISABLE_DATABASE_ENVIRONMENT_CHECK: "1"
       SECRET_KEY_BASE: "some-really-really-long-secret-key-base-123456789"
     volumes:
-      - ../volume/redmine-logs:/var/log/redmine
+      - ../volume/redmine-logs:/var/log/redmine:rw
       - ../volume/redmine-plugins:/usr/src/redmine/plugins
       - ../volume/repos:/home/redmine/repos
       - ../common/config/additional_environment.rb:/usr/src/redmine/config/additional_environment.rb
@@ -244,7 +244,7 @@ services:
       DISABLE_DATABASE_ENVIRONMENT_CHECK: "1"
       SECRET_KEY_BASE: "some-really-really-long-secret-key-base-123456789"
     volumes:
-      - ../volume/redmine-logs:/var/log/redmine
+      - ../volume/redmine-logs:/var/log/redmine:rw
       - ../volume/redmine-plugins:/usr/src/redmine/plugins
       - ../common/config/additional_environment.rb:/usr/src/redmine/config/additional_environment.rb
       - ../volume/repos:/home/redmine/repos
@@ -287,7 +287,7 @@ services:
       DISABLE_DATABASE_ENVIRONMENT_CHECK: "1"
       SECRET_KEY_BASE: "some-really-really-long-secret-key-base-123456789"
     volumes:
-      - ../volume/redmine-logs:/var/log/redmine
+      - ../volume/redmine-logs:/var/log/redmine:rw
       - ../volume/redmine-plugins:/usr/src/redmine/plugins
       - ../volume/repos:/home/redmine/repos
       - ../common/config/additional_environment.rb:/usr/src/redmine/config/additional_environment.rb
@@ -423,13 +423,32 @@ services:
     volumes:
       - ../common/config/promtail.yaml:/etc/promtail/config.yaml
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - ../volume/redmine-logs:/var/log/redmine:ro
+      - ../volume/redmine-logs:/var/log/redmine:rw
       - /var/log/nginx:/var/log/nginx:ro
     command: -config.file=/etc/promtail/config.yaml
     depends_on:
       - loki
     networks:
       - default
+  
+  backup:
+    image: alpine:3.17
+    container_name: backup_container
+    hostname: backup_container
+    restart: unless-stopped
+    # backup-scripts klasörünüzü container içinde /scripts olarak mount
+    volumes:
+      - ../common/backup-scripts:/scripts:ro       # script'ler read-only
+      - ../volume/backups:/db_backups            # yedek dosyaları bu volume'a
+    depends_on:
+      - proxysql       # yedeği proxysql üzerinden alıyoruz
+    command: /bin/sh -c "apk update && apk add --no-cache mariadb-client && /scripts/entrypoint.sh"
+    environment:
+      - MYSQL_HOST=proxysql
+      - MYSQL_PORT=6033
+      - MYSQL_USER=backup_user
+      - MYSQL_PASSWORD=backup_pass
+      - MYSQL_DATABASE=redmine
 
 volumes:
   master_data:
@@ -442,6 +461,7 @@ volumes:
   loki_data:
   grafana_data:
   prometheus_data:
+  backup_data:
   
 networks:
   default:

--- a/with-db/run.sh
+++ b/with-db/run.sh
@@ -159,6 +159,11 @@ initialize_slave() {
         DROP USER IF EXISTS 'redmine'@'%';
         CREATE USER 'redmine'@'%' IDENTIFIED BY 'redmine_password';
         GRANT ALL PRIVILEGES ON *.* TO 'redmine'@'%';
+
+        # ----- YENİ: Backup kullanıcısı oluştur -----
+        DROP USER IF EXISTS 'backup_user'@'%';
+        CREATE USER 'backup_user'@'%' IDENTIFIED BY 'backup_pass';
+        GRANT SELECT, LOCK TABLES, SHOW VIEW, TRIGGER, RELOAD, REPLICATION CLIENT ON *.* TO 'backup_user'@'%';
         
         # Replikasyon ayarlarını yap
         CHANGE MASTER TO 

--- a/with-db/run.sh
+++ b/with-db/run.sh
@@ -96,6 +96,11 @@ initialize_master() {
         DROP USER IF EXISTS 'redmine'@'%';
         CREATE USER 'redmine'@'%' IDENTIFIED BY 'redmine_password';
         GRANT ALL PRIVILEGES ON *.* TO 'redmine'@'%';
+
+        # ----- YENİ: Backup kullanıcısı oluştur -----
+        DROP USER IF EXISTS 'backup_user'@'%';
+        CREATE USER 'backup_user'@'%' IDENTIFIED BY 'backup_pass';
+        GRANT SELECT, LOCK TABLES, SHOW VIEW, TRIGGER, RELOAD, REPLICATION CLIENT ON *.* TO 'backup_user'@'%';
         
         FLUSH PRIVILEGES;
         SET SQL_LOG_BIN=1;"


### PR DESCRIPTION
This pull request introduces a backup solution for the database, including scripts, user creation, and Docker configuration changes. The most important changes are listed below:

### Backup Script and Cron Job

* Added a new backup script `db_backup.sh` to create and compress MySQL database backups.
* Created an entrypoint script `entrypoint.sh` to copy the cron job configuration and start the cron daemon.
* Configured a cron job in `root-cron` to run the backup script every three minutes.

### User and Permissions

* Added a new MySQL user `backup_user` with necessary permissions for backups in `proxysql.cnf`.
* Updated `run.sh` to create the `backup_user` with appropriate permissions on both master and slave databases. [[1]](diffhunk://#diff-fd5ebb07814299638188ee7cf9cb7594f9b8b3ed6d741cfce92eb0267dc0a95dR100-R104) [[2]](diffhunk://#diff-fd5ebb07814299638188ee7cf9cb7594f9b8b3ed6d741cfce92eb0267dc0a95dR163-R167)

### Docker Configuration

* Modified `docker-compose.yml` to add a new service `backup` for running the backup scripts and updated volume permissions for `redmine-logs`. [[1]](diffhunk://#diff-c1b02e6ec350f5ba2cb8f2726f6b01bc6d71350d112e84bdbbf6dc78e64f3bf9L204-R204) [[2]](diffhunk://#diff-c1b02e6ec350f5ba2cb8f2726f6b01bc6d71350d112e84bdbbf6dc78e64f3bf9L247-R247) [[3]](diffhunk://#diff-c1b02e6ec350f5ba2cb8f2726f6b01bc6d71350d112e84bdbbf6dc78e64f3bf9L290-R290) [[4]](diffhunk://#diff-c1b02e6ec350f5ba2cb8f2726f6b01bc6d71350d112e84bdbbf6dc78e64f3bf9L426-R452) [[5]](diffhunk://#diff-c1b02e6ec350f5ba2cb8f2726f6b01bc6d71350d112e84bdbbf6dc78e64f3bf9R464)